### PR TITLE
Explicitly set permissions on Github Actions workflows.

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -4,6 +4,9 @@ jobs:
   hadolint:
     name: runner / hadolint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Check out code
         uses: actions/checkout@v1

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   update-semver:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v1
       - uses: haya14busa/action-update-semver@v1


### PR DESCRIPTION
Sets Github permissions on configured workflows. Note that I _have not tested_ these changes as it's unclear if Smile is even making use of these workflows or how they're meant to be used by Smile, though I believe the changes to be correct.